### PR TITLE
Add note about dashes not allowed in variable names

### DIFF
--- a/PIPELINE_TEMPLATES.md
+++ b/PIPELINE_TEMPLATES.md
@@ -217,6 +217,8 @@ defined in, or in child Templates and Configurations. They required a `name`,
 `description` and optionally `type`, `defaultValue`, `group` and `example`
 fields.
 
+Dashes are not allowed in variable names.
+
 The `type` field accepts:
 
 * `string` (default)


### PR DESCRIPTION
Jinja does not allow dashes, noting it in the spec.
https://github.com/spinnaker/orca/pull/1478