### PR TITLE
update orca-local.yml configuration

### DIFF
--- a/ALPHA-GETTING-STARTED.md
+++ b/ALPHA-GETTING-STARTED.md
@@ -10,7 +10,7 @@ will help you get going.
 In `orca-local.yml`:
 
 ```
-pipelineTemplate:
+pipelineTemplates:
   enabled: true
   jinja:
     enabled: true


### PR DESCRIPTION
Due to https://github.com/spinnaker/orca/pull/1548, the correct stanza for `orca-local.yml` is `pipelineTemplates`.
It is also enabled by default already, so this is not mandatory.