### PR TITLE
Add scope to fix configuration inheritance example

### DIFF
--- a/examples/pipeline-templates-v1/configuration-inheritance/template.yml
+++ b/examples/pipeline-templates-v1/configuration-inheritance/template.yml
@@ -4,6 +4,8 @@ id: configurationInheritance
 metadata:
   name: Configuration Inheritance Example
   description: A simple inheritance example of how to inherit parameters from a template
+  scopes:
+    - global
 
 configuration:
   triggers:


### PR DESCRIPTION
The configuration inheritance example is missing the scopes field from the template, causing spinnaker to reject it.