### PR TITLE
Update README.md - add pipeline2dcd resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,5 @@ Other resources:
   Public repo of Pipeline Templates for examples and sharing.
 * [spin-dcd-converter](https://github.com/robzienert/spin-dcd-converter) -
   Tool to bootstrap converting existing Pipelines to Pipeline Template YAML.
+* [pipeline2dcd](https://github.com/sergi/pipeline2dcd) -
+  Web browser extension to convert JSON Spinnaker pipelines to DCD pipelines.


### PR DESCRIPTION
Today I found this extension. It is actually more updated than spin-dcd-converter and you don't need to pass is an API_SESSION